### PR TITLE
Move to functional components

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -22,7 +22,7 @@ import React from 'react';
 import { Backdrop, Bullseye, Spinner } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody } from '@patternfly/react-table';
 
-import { Patch } from './patch.jsx';
+import { Patch } from './lib/patch';
 
 const _ = cockpit.gettext;
 

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -18,7 +18,7 @@
  */
 
 import cockpit from 'cockpit';
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Backdrop, Bullseye, Spinner } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody } from '@patternfly/react-table';
 
@@ -26,57 +26,53 @@ import { Patch } from './lib/patch';
 
 const _ = cockpit.gettext;
 
-export class Application extends React.Component {
-    constructor() {
-        super();
-        this.state = {
-            loading: true,
-            columns: [
-                "Name",
-                "Version",
-                "Category",
-                "Severity",
-                "Summary"
-            ]
-        };
-    }
+export function Application() {
+    const [loading, setLoading] = useState(true);
+    const [patches, setPatches] = useState([]);
 
-    componentDidMount() {
-        Patch.patches().then((patches) =>
-            this.setState({ patches: patches, loading: false })
+    const columns = [
+        "Name",
+        "Version",
+        "Category",
+        "Severity",
+        "Summary"
+    ];
+
+    useEffect(() => {
+        Patch.patches().then((patches) => {
+            setPatches(patches);
+            setLoading(false);
+        });
+    }, []);
+
+    if (loading) {
+        return (
+            <Backdrop>
+                <Bullseye>
+                    <Spinner />
+                </Bullseye>
+            </Backdrop>
         );
-    }
+    } else {
+        console.log("Rendering patches: ", patches);
 
-    render() {
-        if (this.state.loading)
-            return (
-                <Backdrop>
-                    <Bullseye>
-                        <Spinner />
-                    </Bullseye>
-                </Backdrop>
-            );
-        else {
-            console.log("Rendering patches: ", this.state.patches);
+        const rows = patches.map((patch) => {
+            return {
+                cells: [
+                    patch.name,
+                    patch.version,
+                    patch.category,
+                    patch.severity,
+                    patch.summary
+                ]
+            };
+        });
 
-            const rows = this.state.patches.map((patch) => {
-                return {
-                    cells: [
-                        patch.name,
-                        patch.version,
-                        patch.category,
-                        patch.severity,
-                        patch.summary
-                    ]
-                };
-            });
-
-            return (
-                <Table caption={ _("Available Updates") } cells={this.state.columns} rows={rows}>
-                    <TableHeader />
-                    <TableBody />
-                </Table>
-            );
-        }
+        return (
+            <Table caption={ _("Available Updates") } cells={columns} rows={rows}>
+                <TableHeader />
+                <TableBody />
+            </Table>
+        );
     }
 }

--- a/src/lib/patch.js
+++ b/src/lib/patch.js
@@ -1,3 +1,23 @@
+/*
+ * Copyright (c) [2020] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
 
 import cockpit from 'cockpit';
 

--- a/src/lib/patch.js
+++ b/src/lib/patch.js
@@ -30,21 +30,16 @@ export class Patch {
 
         const updates = xmlDoc.getElementsByTagName("update");
 
-        const patches = [];
-        for (let i = 0; i < updates.length; i++) {
-            const update = updates[i];
-
-            patches.push(new Patch(
+        return Array.from(updates).map((update) => {
+            return new Patch(
                 update.getAttribute("name"),
                 update.getAttribute("edition"),
                 update.getAttribute("category"),
                 update.getAttribute("severity"),
                 update.getElementsByTagName("summary")[0].textContent,
                 update.getElementsByTagName("description")[0].textContent
-            ));
-        }
-
-        return patches;
+            );
+        });
     }
 
     constructor(name, version, category, severity, summary, description) {


### PR DESCRIPTION
In the past, only class-based components were able to handle state. However, since the introduction of [hooks](https://en.reactjs.org/docs/hooks-reference.html), that it is not the case anymore. Usually, it is preferred to use functional components instead of class-based ones. In general, they need less code, are simpler (they are just functions) and easier to test.

On the other hand, this PR introduces some minor changes to the Patch class.