### PR TITLE
Patches selection for installation

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -18,10 +18,11 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { Page, PageSection, PageSectionVariants, Text } from '@patternfly/react-core';
+import { Page, PageSection, PageSectionVariants } from '@patternfly/react-core';
 import { Patch } from './lib/patch';
 import { Loading } from './components/Loading';
 import { PatchesList } from './components/PatchesList';
+import { UpdatedSystemNotice } from './components/UpdatedSystemNotice';
 import cockpit from 'cockpit';
 
 const _ = cockpit.gettext;
@@ -58,6 +59,10 @@ export function Application() {
             />
         );
     };
+
+    if (!loading && patches.length === 0) {
+        return <UpdatedSystemNotice />;
+    }
 
     return (
         <Page>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -17,26 +17,15 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import cockpit from 'cockpit';
 import React, { useState, useEffect } from 'react';
-import { Backdrop, Bullseye, Spinner } from '@patternfly/react-core';
-import { Table, TableHeader, TableBody } from '@patternfly/react-table';
 
 import { Patch } from './lib/patch';
-
-const _ = cockpit.gettext;
+import { Loading } from './components/Loading';
+import { PatchesList } from './components/PatchesList';
 
 export function Application() {
     const [loading, setLoading] = useState(true);
     const [patches, setPatches] = useState([]);
-
-    const columns = [
-        "Name",
-        "Version",
-        "Category",
-        "Severity",
-        "Summary"
-    ];
 
     useEffect(() => {
         Patch.patches().then((patches) => {
@@ -46,33 +35,10 @@ export function Application() {
     }, []);
 
     if (loading) {
-        return (
-            <Backdrop>
-                <Bullseye>
-                    <Spinner />
-                </Bullseye>
-            </Backdrop>
-        );
-    } else {
-        console.log("Rendering patches: ", patches);
-
-        const rows = patches.map((patch) => {
-            return {
-                cells: [
-                    patch.name,
-                    patch.version,
-                    patch.category,
-                    patch.severity,
-                    patch.summary
-                ]
-            };
-        });
-
-        return (
-            <Table caption={ _("Available Updates") } cells={columns} rows={rows}>
-                <TableHeader />
-                <TableBody />
-            </Table>
-        );
+        return <Loading />;
     }
+
+    return (
+        <PatchesList patches={patches} />
+    );
 }

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -18,10 +18,14 @@
  */
 
 import React, { useState, useEffect } from 'react';
-
+import { Page, PageSection, PageSectionVariants, Text } from '@patternfly/react-core';
 import { Patch } from './lib/patch';
 import { Loading } from './components/Loading';
 import { PatchesList } from './components/PatchesList';
+import cockpit from 'cockpit';
+
+const _ = cockpit.gettext;
+const n_ = cockpit.ngettext;
 
 export function Application() {
     const [loading, setLoading] = useState(true);
@@ -34,14 +38,37 @@ export function Application() {
         });
     }, []);
 
-    if (loading) {
-        return <Loading />;
-    }
+    const statusText = () => {
+        if (loading) {
+            return _('Loading available patches. Please, wait...');
+        } else {
+            return n_('1 patch found', `${patches.length} patches found`, patches.length);
+        }
+    };
+
+    const content = () => {
+        if (loading) {
+            return <Loading />;
+        }
+
+        return (
+            <PatchesList
+                patches={patches}
+                onSubmit={ names => console.log(`Installing ${names}`) }
+            />
+        );
+    };
 
     return (
-        <PatchesList
-            patches={patches}
-            onSubmit={ names => console.log(`Installing ${names}`) }
-        />
+        <Page>
+            <PageSection className="content-header-extra">
+                <div id="state" className="content-header-extra--state">
+                    {statusText()}
+                </div>
+            </PageSection>
+            <PageSection variant={PageSectionVariants.light}>
+                {content()}
+            </PageSection>
+        </Page>
     );
 }

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -39,6 +39,9 @@ export function Application() {
     }
 
     return (
-        <PatchesList patches={patches} />
+        <PatchesList
+            patches={patches}
+            onSubmit={ names => console.log(`Installing ${names}`) }
+        />
     );
 }

--- a/src/app.scss
+++ b/src/app.scss
@@ -27,3 +27,8 @@
         padding-right: 1ex;
     }
 }
+
+.pf-c-card__title {
+   font-size: var(--pf-global--FontSize--2xl);
+   font-weight: var(--pf-global--FontWeight--normal);
+}

--- a/src/app.scss
+++ b/src/app.scss
@@ -1,3 +1,29 @@
-p {
-    font-weight: bold;
+/* Try to make it look like the packagekit module. "Stolen" from cockpit's file
+   pkg/packagekit/updates.scss. */
+.content-header-extra {
+    background: #f5f5f5;
+    border-bottom: 1px solid #ddd;
+    padding: 10px 20px;
+    width: 100%;
+    z-index: 900;
+    top: 0;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    align-items: center;
+    min-height: 4rem;
+
+    @media screen and (min-width: 640px) {
+        position: sticky;
+    }
+
+    &--state {
+        /* Make the height similar to the button (2px padding + 1px border) */
+        padding: 3px 0;
+    }
+
+    &--state {
+        flex: 100 1 auto;
+        padding-right: 1ex;
+    }
 }

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -20,14 +20,12 @@
  */
 
 import React from 'react';
-import { Backdrop, Bullseye, Spinner } from '@patternfly/react-core';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 
 export function Loading() {
     return (
-        <Backdrop>
-            <Bullseye>
-                <Spinner />
-            </Bullseye>
-        </Backdrop>
+        <Bullseye>
+            <Spinner />
+        </Bullseye>
     );
 }

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) [2020] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from 'react';
+import { Backdrop, Bullseye, Spinner } from '@patternfly/react-core';
+
+export function Loading() {
+    return (
+        <Backdrop>
+            <Bullseye>
+                <Spinner />
+            </Bullseye>
+        </Backdrop>
+    );
+}

--- a/src/components/PatchDetails.js
+++ b/src/components/PatchDetails.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) [2020] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from 'react';
+
+export function PatchDetails({ patch }) {
+    // TODO: parse an build a proper set of TextContent components
+    return (
+        <pre>{patch.description}</pre>
+    );
+}

--- a/src/components/PatchesList.js
+++ b/src/components/PatchesList.js
@@ -19,39 +19,108 @@
  * find current contact information at www.suse.com.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
+import { Button, Card, CardHeader, CardActions, CardTitle, CardBody } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody } from '@patternfly/react-table';
+import { PatchDetails } from './PatchDetails';
 import cockpit from 'cockpit';
 
 const _ = cockpit.gettext;
 
-export function PatchesList({ patches }) {
-    console.debug("Rendering patches: ", patches);
-
-    const columns = [
-        "Name",
-        "Version",
-        "Category",
-        "Severity",
-        "Summary"
-    ];
-
-    const rows = patches.map((patch) => {
-        return {
+/**
+ * Builds the needed structure for rendering the patches and their details in an expandable
+ * Patternfly/Table
+ */
+const buildRows = (patchesList) => (
+    patchesList.reduce((list, patch, rowId) => {
+        const parentRow = {
+            isOpen: false,
+            selected: false,
             cells: [
                 patch.name,
                 patch.version,
                 patch.category,
                 patch.severity,
-                patch.summary
+                patch.summary,
             ]
         };
-    });
+        const detailsRow = {
+            parent: rowId * 2,
+            cells: [
+                { title: <PatchDetails patch={patch} /> }
+            ]
+        };
+
+        return [...list, parentRow, detailsRow];
+    }, [])
+);
+
+export function PatchesList({ patches, onSubmit }) {
+    const [rows, setRows] = useState(buildRows(patches));
+    const [selectedRows, setSelectedRows] = useState([]);
+
+    const columns = [
+        _("Name"),
+        _("Version"),
+        _("Category"),
+        _("Severity"),
+        _("Summary")
+    ];
+
+    const onCollapse = (event, rowId, isOpen) => {
+        const newRows = rows.map((row, idx) => (
+            { ...row, isOpen: (rowId === idx) ? isOpen : row.isOpen }
+        ));
+        setRows(newRows);
+    };
+
+    const onSelect = (event, isSelected, rowId) => {
+        const newRows = rows.map((row, idx) => (
+            { ...row, selected: (rowId === -1 || rowId === idx) ? isSelected : row.selected }
+        ));
+        setRows(newRows);
+
+        if (isSelected && !selectedRows.includes(rowId)) {
+            setSelectedRows([...selectedRows, rowId]);
+        } else {
+            setSelectedRows(selectedRows.filter(r => r !== rowId));
+        }
+    };
+
+    const onSubmitFn = () => {
+        const names = selectedRows.map(r => rows[r].cells[0]);
+        onSubmit(names);
+    };
 
     return (
-        <Table caption={ _("Available Updates") } cells={columns} rows={rows}>
-            <TableHeader />
-            <TableBody />
-        </Table>
+        <Card>
+            <CardHeader>
+                <CardActions>
+                    { onSubmit &&
+                    <Button
+                        variant="primary"
+                        isDisabled={selectedRows.length === 0}
+                        onClick={onSubmitFn}
+                    >
+                        {_("Install Patches")}
+                    </Button> }
+                </CardActions>
+                <CardTitle><h2>{_("Available Updates")}</h2></CardTitle>
+            </CardHeader>
+            <CardBody>
+                <Table
+                    aria-label={_("Available Updates")}
+                    cells={columns}
+                    rows={rows}
+                    onCollapse={onCollapse}
+                    onSelect={onSelect}
+                    canSelectAll
+                    variant="compact"
+                >
+                    <TableHeader />
+                    <TableBody />
+                </Table>
+            </CardBody>
+        </Card>
     );
 }

--- a/src/components/PatchesList.js
+++ b/src/components/PatchesList.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) [2020] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from 'react';
+import { Table, TableHeader, TableBody } from '@patternfly/react-table';
+import cockpit from 'cockpit';
+
+const _ = cockpit.gettext;
+
+export function PatchesList({ patches }) {
+    console.debug("Rendering patches: ", patches);
+
+    const columns = [
+        "Name",
+        "Version",
+        "Category",
+        "Severity",
+        "Summary"
+    ];
+
+    const rows = patches.map((patch) => {
+        return {
+            cells: [
+                patch.name,
+                patch.version,
+                patch.category,
+                patch.severity,
+                patch.summary
+            ]
+        };
+    });
+
+    return (
+        <Table caption={ _("Available Updates") } cells={columns} rows={rows}>
+            <TableHeader />
+            <TableBody />
+        </Table>
+    );
+}

--- a/src/components/PatchesList.js
+++ b/src/components/PatchesList.js
@@ -105,7 +105,7 @@ export function PatchesList({ patches, onSubmit }) {
                         {_("Install Patches")}
                     </Button> }
                 </CardActions>
-                <CardTitle><h2>{_("Available Updates")}</h2></CardTitle>
+                <CardTitle>{_("Available Updates")}</CardTitle>
             </CardHeader>
             <CardBody>
                 <Table

--- a/src/components/UpdatedSystemNotice.js
+++ b/src/components/UpdatedSystemNotice.js
@@ -35,7 +35,7 @@ export function UpdatedSystemNotice() {
         <EmptyState>
             <EmptyStateIcon icon={CheckCircle} />
             <Title headingLevel="h4" size="lg">
-                Your System is Updated
+                {_('Your System is Updated')}
             </Title>
 
             <EmptyStateBody>

--- a/src/components/UpdatedSystemNotice.js
+++ b/src/components/UpdatedSystemNotice.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) [2020] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+import React from 'react';
+import {
+    EmptyState,
+    EmptyStateIcon,
+    EmptyStateBody,
+    Title
+} from '@patternfly/react-core';
+import CheckCircle from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
+import cockpit from 'cockpit';
+
+const _ = cockpit.gettext;
+
+export function UpdatedSystemNotice() {
+    return (
+        <EmptyState>
+            <EmptyStateIcon icon={CheckCircle} />
+            <Title headingLevel="h4" size="lg">
+                Your System is Updated
+            </Title>
+
+            <EmptyStateBody>
+                {_('There are no patches pending for installation.')}
+            </EmptyStateBody>
+        </EmptyState>
+    );
+}


### PR DESCRIPTION
This PR extends the existing patches list with support for selecting patches for installation. Once the user selects some package, it is possible to click the `Install Patches` button which runs a custom function (the real function is not ready yet). If no patch is selected, the button remains disabled.

![patches-list](https://user-images.githubusercontent.com/15836/99061713-de9d3200-2599-11eb-91aa-dbb585c75a5f.gif)

Apart from selecting/unselecting patches, the user can expand/collapse each patch to find out additional details.

And if no patches are pending for installation, the user gets a nice notice about it.

![system-updated](https://user-images.githubusercontent.com/15836/98933976-4b042c80-24d9-11eb-9017-2216e09a7b52.png)

## To do

- [ ] ~Improve the packages description avoiding the dirty trick of using `<pre>` to keep the newlines :)~ (let's keep it by now).
- [x] Fix the titles and, probably, the layout of the whole page.
- [ ] Connect with the real function to perform the update (future).
- [x] Improve the feedback while the list of patches is being retrieved.