### PR TITLE
Add snapshots tab

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -17,63 +17,32 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useEffect } from 'react';
-import { Page, PageSection, PageSectionVariants } from '@patternfly/react-core';
-import { Patch } from './lib/patch';
-import { Loading } from './components/Loading';
-import { PatchesList } from './components/PatchesList';
-import { UpdatedSystemNotice } from './components/UpdatedSystemNotice';
+import React, { useState } from 'react';
+import {
+    Page,
+    Tabs,
+    Tab,
+    TabTitleText
+} from '@patternfly/react-core';
+import { PatchesTab } from './components/PatchesTab';
 import cockpit from 'cockpit';
 
 const _ = cockpit.gettext;
-const n_ = cockpit.ngettext;
 
 export function Application() {
-    const [loading, setLoading] = useState(true);
-    const [patches, setPatches] = useState([]);
+    const [activeKey, setActiveKey] = useState(0);
 
-    useEffect(() => {
-        Patch.patches().then((patches) => {
-            setPatches(patches);
-            setLoading(false);
-        });
-    }, []);
-
-    const statusText = () => {
-        if (loading) {
-            return _('Loading available patches. Please, wait...');
-        } else {
-            return n_('1 patch found', `${patches.length} patches found`, patches.length);
-        }
+    const handleTabClick = (event, tabIndex) => {
+        setActiveKey(tabIndex);
     };
-
-    const content = () => {
-        if (loading) {
-            return <Loading />;
-        }
-
-        return (
-            <PatchesList
-                patches={patches}
-                onSubmit={ names => console.log(`Installing ${names}`) }
-            />
-        );
-    };
-
-    if (!loading && patches.length === 0) {
-        return <UpdatedSystemNotice />;
-    }
 
     return (
-        <Page>
-            <PageSection className="content-header-extra">
-                <div id="state" className="content-header-extra--state">
-                    {statusText()}
-                </div>
-            </PageSection>
-            <PageSection variant={PageSectionVariants.light}>
-                {content()}
-            </PageSection>
+        <Page id="transactional-update">
+            <Tabs activeKey={activeKey} onSelect={handleTabClick}>
+                <Tab eventKey={0} title={<TabTitleText>{_("Patches")}</TabTitleText>}>
+                    <PatchesTab />
+                </Tab>
+            </Tabs>
         </Page>
     );
 }

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -25,6 +25,7 @@ import {
     TabTitleText
 } from '@patternfly/react-core';
 import { PatchesTab } from './components/PatchesTab';
+import { SnapshotsTab } from './components/SnapshotsTab';
 import cockpit from 'cockpit';
 
 const _ = cockpit.gettext;
@@ -38,9 +39,12 @@ export function Application() {
 
     return (
         <Page id="transactional-update">
-            <Tabs activeKey={activeKey} onSelect={handleTabClick}>
+            <Tabs mountOnEnter activeKey={activeKey} onSelect={handleTabClick}>
                 <Tab eventKey={0} title={<TabTitleText>{_("Patches")}</TabTitleText>}>
                     <PatchesTab />
+                </Tab>
+                <Tab eventKey={1} title={<TabTitleText>{_("Snapshots")}</TabTitleText>}>
+                    <SnapshotsTab />
                 </Tab>
             </Tabs>
         </Page>

--- a/src/components/PatchesTab.js
+++ b/src/components/PatchesTab.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) [2020] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+    PageSection,
+    PageSectionVariants
+} from '@patternfly/react-core';
+import { Patch } from '../lib/patch';
+import { Loading } from './Loading';
+import { UpdatedSystemNotice } from './UpdatedSystemNotice';
+import { PatchesList } from './PatchesList';
+import cockpit from 'cockpit';
+
+const _ = cockpit.gettext;
+const n_ = cockpit.ngettext;
+
+export function PatchesTab() {
+    const [loading, setLoading] = useState(true);
+    const [patches, setPatches] = useState([]);
+
+    useEffect(() => {
+        Patch.patches().then((patches) => {
+            setPatches(patches);
+            setLoading(false);
+        });
+    }, []);
+
+    const statusText = () => {
+        if (loading) {
+            return _('Loading available patches. Please, wait...');
+        } else {
+            return n_('1 patch found', `${patches.length} patches found`, patches.length);
+        }
+    };
+
+    const content = () => {
+        if (loading) {
+            return <Loading />;
+        }
+
+        return (
+            <PatchesList
+                patches={patches}
+                onSubmit={ names => console.log(`Installing ${names}`) }
+            />
+        );
+    };
+
+    if (!loading && patches.length === 0) {
+        return <UpdatedSystemNotice />;
+    }
+
+    return (
+        <>
+            <PageSection className="content-header-extra">
+                <div id="state" className="content-header-extra--state">
+                    {statusText()}
+                </div>
+            </PageSection>
+            <PageSection variant={PageSectionVariants.light}>
+                {content()}
+            </PageSection>
+        </>
+    );
+}

--- a/src/components/SnapshotsList.js
+++ b/src/components/SnapshotsList.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) [2020] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useState } from 'react';
+import { Card, CardHeader, CardBody, CardTitle } from '@patternfly/react-core';
+import {
+    Table,
+    TableHeader,
+    TableBody
+} from '@patternfly/react-table';
+import cockpit from 'cockpit';
+
+const _ = cockpit.gettext;
+
+const buildRows = (snapshotsList) => (
+    snapshotsList.map((snapshot) => (
+        {
+            rowKey: snapshot.id,
+            cells: [
+                snapshot.id,
+                snapshot.date.toLocaleString()
+            ],
+            active: snapshot.active,
+            current: snapshot.current
+        }
+    ))
+);
+
+export function SnapshotsList({ snapshots, onRebootRequest, onRollbackRequest }) {
+    const [rows] = useState(buildRows(snapshots));
+
+    const columns = [
+        _("Number"), _("Date")
+    ];
+
+    const actionResolver = ({ id, active, current }) => {
+        if (active && current) {
+            return null;
+        }
+
+        if (!current) {
+            return [{ title: _('Rollback'), onClick: onRollbackRequest }];
+        } else {
+            return [{ title: _('Reboot'), onClick: onRebootRequest }];
+        }
+    };
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>{_("Existing Snapshots")}</CardTitle>
+            </CardHeader>
+            <CardBody>
+                <Table
+                    aria-label={_("Existing Snapshots")}
+                    cells={columns}
+                    rows={rows}
+                    variant="compact"
+                    actionResolver={actionResolver}
+                >
+                    <TableHeader />
+                    <TableBody />
+                </Table>
+            </CardBody>
+        </Card>
+    );
+}

--- a/src/components/SnapshotsTab.js
+++ b/src/components/SnapshotsTab.js
@@ -19,24 +19,62 @@
  * find current contact information at www.suse.com.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import {
     PageSection,
     PageSectionVariants
 } from '@patternfly/react-core';
+import { Loading } from './Loading';
+import { SnapshotsList } from './SnapshotsList';
 import cockpit from 'cockpit';
 
 const _ = cockpit.gettext;
+const n_ = cockpit.ngettext;
+
+/**
+ * Dummy data. Just replace with data from the D-Bus service.
+ */
+const dummySnapshots = [
+    { id: 2, date: new Date('2020-11-16 10:02') },
+    { id: 1, date: new Date('2020-11-15 14:30'), current: true },
+    { id: 0, date: new Date('2020-11-10 12:00'), active: true }
+];
 
 export function SnapshotsTab() {
+    const [loading] = useState(false);
+    const [snapshots] = useState(dummySnapshots);
+
+    const statusText = () => {
+        if (loading) {
+            return _('Loading existing snapshots. Please, wait...');
+        } else {
+            return n_('1 snapshot found', `${snapshots.length} snapshots found`, snapshots.length);
+        }
+    };
+
+    const content = () => {
+        if (loading) {
+            return <Loading />;
+        }
+
+        return (
+            <SnapshotsList
+                snapshots={snapshots}
+                onRollbackRequest={(event, id) => console.log('Rolling back to snapshot', id)}
+            />
+        );
+    };
+
     return (
         <>
             <PageSection className="content-header-extra">
                 <div id="state" className="content-header-extra--state">
-                    {_('Loading existing snapshots. Please, wait...')}
+                    { statusText() }
                 </div>
             </PageSection>
-            <PageSection variant={PageSectionVariants.light} />
+            <PageSection variant={PageSectionVariants.light}>
+                { content() }
+            </PageSection>
         </>
     );
 }

--- a/src/components/SnapshotsTab.js
+++ b/src/components/SnapshotsTab.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) [2020] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from 'react';
+import {
+    PageSection,
+    PageSectionVariants
+} from '@patternfly/react-core';
+import cockpit from 'cockpit';
+
+const _ = cockpit.gettext;
+
+export function SnapshotsTab() {
+    return (
+        <>
+            <PageSection className="content-header-extra">
+                <div id="state" className="content-header-extra--state">
+                    {_('Loading existing snapshots. Please, wait...')}
+                </div>
+            </PageSection>
+            <PageSection variant={PageSectionVariants.light} />
+        </>
+    );
+}


### PR DESCRIPTION
Adds a list of snapshots using dummy data. It is just a PoC because there is not much data to show regarding a snapshot yet. Finally, the actions at each row are:

* "Rollback" is the snapshot is not the default one;
* "Reboot" is the snapshot is the default one but it is not active.

There are many things to improve, like indicating which is the default snapshot, improving the date/time format, etc. And, of course, displaying real data.

![snapshots-list](https://user-images.githubusercontent.com/15836/99251254-edd3e800-2804-11eb-89fd-c91b852dcdd5.png)
